### PR TITLE
Fixed no include possible with CMake exported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,6 @@ target_compile_features(${PROJECT_NAME}
         cxx_std_11
 )
 
-
 if (NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "debug")
 endif()


### PR DESCRIPTION
Linking to the library is possible but no include directories are set when this library is exported with FetchContent.